### PR TITLE
fix: azure configuration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18 <20"
   },
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "therabot_landing",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,0 +1,5 @@
+{
+  "platform": {
+    "apiRuntime": "node:18"
+  }
+}


### PR DESCRIPTION
Add azure configuration file to specify the Node version.

NextJS 14 does not support node 16 anymore as referenced [here](https://nextjs.org/docs/pages/building-your-application/upgrading/version-14#v14-summary).
