### PR TITLE
fix: animation transitions causing overflow

### DIFF
--- a/app/(landing)/page.tsx
+++ b/app/(landing)/page.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
 
 function page() {
   return (
-    <div className="bg-white w-screen overflow-x-hidden">
+    <div className="bg-white">
       <First />
       <Banner />
       <Interests />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -56,9 +56,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className="scroll-smooth">
       <head />
-      <body className={`${inter.className}`}>
+      <body className={`${inter.className} w-screen overflow-x-hidden`}>
         <Providers>
           <Nav />
           {children}

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -12,18 +12,27 @@ export const Nav = () => {
   };
 
   useEffect(() => {
-    window.addEventListener('scroll', () => {
-      if(window.scrollY > 20) {
-        setActivated(true)
+    // let's initially check if user is reloading and in a target scroll postion
+    if (window.scrollY > 10) {
+      setActivated(true);
+    }
+    window.addEventListener("scroll", () => {
+      if (window.scrollY > 10) {
+        setActivated(true);
+      } else {
+        setActivated(false);
       }
-      else {
-        setActivated(false)
-      }
-    })
-  }, [])
+    });
+  }, []);
 
   return (
-    <nav className={`${activated ? 'bg-white border-gray-200' : 'bg-transparent border-transparent'} border-b w-full transition-colors ease-in duration-200 text-gray-900  fixed z-20 top-0 start-0 `}>
+    <nav
+      className={`${
+        activated
+          ? "bg-white border-gray-200"
+          : "bg-transparent border-transparent"
+      } border-b fixed w-full transition-colors ease-in duration-200 text-gray-900  z-20 top-0 start-0 `}
+    >
       <div className="flex flex-wrap items-center justify-between mx-auto px-4 max-w-[100vw]  py-2">
         <a href="/" className="flex items-center space-x-3 rtl:space-x-reverse">
           <Image

--- a/components/landing/interests.tsx
+++ b/components/landing/interests.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @next/next/no-img-element */
 "use client";
 import { INTERESTS, Interest } from "@/constants/interests";
-import { fadeFromLeft, fadeFromRight, popOut } from "@/utils/animations";
+import { fadeFromLeft, fadeFromRight, popOut, riseWithFade } from "@/utils/animations";
 import { motion, useAnimation, useInView } from "framer-motion";
 import { useEffect, useRef } from "react";
 
@@ -46,21 +46,21 @@ export default function Interests() {
         <div className="py-8 px-4 sm:mx-12 max-w-screen-xl text-center lg:py-16 z-10 relative">
           <div className="sm:px-10 w-full sm:w-4/5 mx-auto">
             <motion.h2
-              variants={fadeFromRight}
+              variants={riseWithFade}
               animate={control1}
               ref={ref1}
               initial="initial"
-              className="text-4xl font-medium text-center duration-[800ms]"
+              className="text-4xl font-medium text-center duration-[600ms]"
             >
               CHOOSE WHAT INTEREST YOU
             </motion.h2>
             <br />
             <motion.p
-              variants={fadeFromLeft}
+              variants={riseWithFade}
               animate={control2}
               ref={ref2}
               initial="initial"
-              className="duration-[800ms]"
+              className="duration-[600ms]"
             >
               Psychotherapy is a form of therapeutic treatment that focuses on
               improving mental health conditions through counseling and talk
@@ -79,7 +79,8 @@ export default function Interests() {
                 ref={interestRefs[index]}
                 initial="initial"
                 key={interest.label}
-                className="flex group flex-col gap-3 duration-500"
+                style={{transitionDelay: `${200 + ((index + 1) * 2 * 100)}ms`}}
+                className={`flex group delay-[${200 + ((index + 1) * 4 * 100)}ms] delay-75 flex-col gap-3 duration-[500ms]`}
               >
                 <img
                   className="rounded-2xl"

--- a/hooks/screen.ts
+++ b/hooks/screen.ts
@@ -1,0 +1,4 @@
+export function useScreenSize() {
+    const isMobile = window.innerWidth < 768;
+    return { isMobile }
+}

--- a/utils/animations.ts
+++ b/utils/animations.ts
@@ -1,14 +1,19 @@
+import { delay } from "framer-motion"
+
 export const fallWithFade = {
     initial: {
-        y: -50,
+        y: -30,
         opacity: 0
     },
     animate: {
         y: 0,
         opacity: 1,
         transition: {
-            type: "smooth",
-            // ease: [0.6, 0.01, 0.05, 0.95],
+            y: {
+                type: "smooth",
+                stiffness: 10,
+            },
+            ease: [0.6, 0.01, 0.05, 0.95],
             duration: 0,
         },
     },
@@ -23,9 +28,14 @@ export const riseWithFade = {
         y: 0,
         opacity: 1,
         transition: {
+            y: {
+                type: "smooth",
+                stiffness: 10,
+            },
             type: "smooth",
             // ease: [0.6, 0.01, 0.05, 0.95],
             duration: 0,
+
         },
     },
 }
@@ -40,6 +50,10 @@ export const fadeFromLeft = {
         x: 0,
         opacity: 1,
         transition: {
+            x: {
+                type: "smooth",
+                stiffness: 10,
+            },
             type: "smooth",
             // ease: [0.6, 0.01, 0.05, 0.95],
             duration: 0,
@@ -57,6 +71,10 @@ export const fadeFromRight = {
         x: 0,
         opacity: 1,
         transition: {
+            x: {
+                type: "smooth",
+                stiffness: 10,
+            },
             type: "smooth",
             // ease: [0.6, 0.01, 0.05, 0.95],
             duration: 0,
@@ -74,6 +92,10 @@ export const slideFromLeft = {
         x: 0,
         opacity: 1,
         transition: {
+            x: {
+                type: "smooth",
+                stiffness: 10,
+            },
             type: "smooth",
             // ease: [0.6, 0.01, 0.05, 0.95],
             duration: 0,
@@ -92,6 +114,10 @@ export const slideFromRight = {
         x: 0,
         opacity: 1,
         transition: {
+            x: {
+                type: "smooth",
+                stiffness: 10,
+            },
             type: "smooth",
             // ease: [0.6, 0.01, 0.05, 0.95],
             duration: 0,
@@ -102,11 +128,9 @@ export const slideFromRight = {
 export const popOut = {
     initial: {
         opacity: 0,
-        scale: 0.5,
     },
     animate: {
         opacity: 1,
-        scale: 1,
         transition: {
             type: "smooth",
             duration: 0


### PR DESCRIPTION
Animations initial state was causing an overflow, causing unwanted scroll on a non-root element.